### PR TITLE
Update guideline-03.md

### DIFF
--- a/guideline-03.md
+++ b/guideline-03.md
@@ -1,3 +1,15 @@
 # 3. Purpose minimisation
 
 Only collect and process personal data for the purpose it was intended for, and for which the user was clearly informed of in advance;
+
+Checklist *
+- We have clearly identified our purpose or purposes for processing.
+- We have documented those purposes.
+- We include details of our purposes in our privacy information for individuals.
+- We regularly review our processing and, where necessary, update our documentation and our privacy information for individuals.
+- If we plan to use personal data for a new purpose, we check that this is compatible with our original purpose or we get specific consent for the new purpose.
+
+Example *
+- A GP discloses his patient list to his wife, who runs a travel agency, so that she can offer special holiday deals to patients needing recuperation. Disclosing the information for this purpose would be incompatible with the purposes for which it was obtained.
+
+(* Information Commissioner’s Office, Principle (b): Purpose limitation, licensed under the Open Government Licence.)


### PR DESCRIPTION
I think it would make sense to reuse at least partially ICO's content regarding this topic.
https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/principles/purpose-limitation/

I know, there is the "GDPR label" on it, but the scope principle is really well defined and can be used for generic privacy purposes.
And there is also a great advantage: it is not a "legal" content, but it helps the implementation/understanding with real-life examples, checklists.

It's license allows the reuse of it (https://ico.org.uk/global/copyright-and-re-use-of-materials/).